### PR TITLE
fix: Update to setting env variable

### DIFF
--- a/react-app/.github/actions/hello-docker/entrypoint.sh
+++ b/react-app/.github/actions/hello-docker/entrypoint.sh
@@ -21,4 +21,4 @@ echo 'some stuff'
 echo 'some stuff'
 echo '::endgroup::'
 
-echo "{HELLO}={hello}" >> $GITHUB_ENV
+echo "HELLO=hello" >> $GITHUB_ENV

--- a/react-app/.github/actions/hello-docker/entrypoint.sh
+++ b/react-app/.github/actions/hello-docker/entrypoint.sh
@@ -21,4 +21,4 @@ echo 'some stuff'
 echo 'some stuff'
 echo '::endgroup::'
 
-echo '::set-env name=HELLO::hello'
+echo "{HELLO}={hello}" >> $GITHUB_ENV


### PR DESCRIPTION
`set-env` is deprecated due to a security vulnerability. https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

Updated to the new way of setting env variables as describe in https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files